### PR TITLE
Add numeric representation of framework options

### DIFF
--- a/graminescaffolding/__main__.py
+++ b/graminescaffolding/__main__.py
@@ -13,7 +13,8 @@ import tomli
 import click
 
 from .frameworks.common.builder import GramineBuilder
-from .utils import gramine_enable_prompts, gramine_option_prompt
+from .utils import (gramine_enable_prompts, gramine_option_prompt,
+    gramine_option_numerical_prompt)
 
 FRAMEWORK_ENTRY_POINTS_GROUP = 'gramine.scaffolding.framework'
 
@@ -68,7 +69,9 @@ def list_framework():
     """
     # TODO after python (>=3.10): remove disable
     # pylint: disable=unexpected-keyword-arg
-    return [entry.name for entry in entry_points(group=FRAMEWORK_ENTRY_POINTS_GROUP)]
+    return sorted([
+        entry.name for entry in entry_points(group=FRAMEWORK_ENTRY_POINTS_GROUP)
+    ])
 
 def load_framework(name):
     """
@@ -123,7 +126,7 @@ def quickstart():
 
 
 @main.command('setup', context_settings={'ignore_unknown_options': True})
-@gramine_option_prompt('--framework', required=True,
+@gramine_option_numerical_prompt('--framework', required=True,
     type=click.Choice(list_framework()), prompt='Which framework you want to use?',
     help='The framework used by the scaffolded application.')
 @gramine_option_prompt('--sgx',

--- a/graminescaffolding/utils.py
+++ b/graminescaffolding/utils.py
@@ -22,6 +22,26 @@ class GramineStorePrompt(click.Option):
     def restore_prompt(self):
         self.prompt = self.default_prompt
 
+class GramineNumberOptions(GramineStorePrompt):
+    def prompt_for_value(self, ctx):
+        if not hasattr(self.type, 'choices') or not self.type.choices:
+            return super().prompt_for_value(ctx)
+
+        click.echo(f'{self.prompt}')
+        for idx, name in enumerate(self.type.choices, 1):
+            click.echo(f'{idx} - {name}')
+
+        while True:
+            choice = click.prompt('Please provide a number or name')
+            try:
+                return self.type.choices[int(choice) - 1]
+            except ValueError:
+                for name in self.type.choices:
+                    if name == choice:
+                        return name
+            except IndexError:
+                click.echo('Invalid option. Try Again.')
+
 def gramine_option_prompt(*param_decls, **attrs):
     """
     This decorator disables the prompt in an option. You can manually enable
@@ -33,6 +53,16 @@ def gramine_option_prompt(*param_decls, **attrs):
     interactive version of the setup.
     """
     return click.option(*param_decls, **attrs, cls=GramineStorePrompt)
+
+def gramine_option_numerical_prompt(*param_decls, **attrs):
+    """
+    This decorator enhances the gramine_option_prompt class; for initial guidance,
+    consult that orginal class.
+
+    The distinction here lies in the acceptance of prompt options in two formats:
+    by name and through a sequence number.
+    """
+    return click.option(*param_decls, **attrs, cls=GramineNumberOptions)
 
 def gramine_enable_prompts(func):
     """


### PR DESCRIPTION
In interactive mode, enable the selection of framework by either providing its name as a string or its sequence number.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/intel/ScaffoldingForGramine/2)
<!-- Reviewable:end -->
