### PR TITLE
python_plain: Enable remote DCAP attestation

### DIFF
--- a/graminescaffolding/templates/frameworks/python_plain/python_plain.manifest.template
+++ b/graminescaffolding/templates/frameworks/python_plain/python_plain.manifest.template
@@ -26,6 +26,7 @@ sys.stack.size = "2M"
 sys.enable_extra_runtime_domain_names_conf = true
 
 sgx.debug = true
+sgx.remote_attestation = "dcap"
 sgx.nonpie_binary = true
 sgx.enclave_size = "1G"
 sgx.max_threads = 32
@@ -40,6 +41,8 @@ sgx.trusted_files = [
   "file:{{ path }}{{ '/' if path.is_dir() else '' }}",
 {% endfor %}
   "file:/app/",
+{% block trusted_files %}
+{% endblock %}
 ]
 {% endraw %}
 


### PR DESCRIPTION
As we are here, allow to add new trusted_files.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/intel/ScaffoldingForGramine/5)
<!-- Reviewable:end -->
