### PR TITLE
README,debian/: install docker

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -45,7 +45,7 @@ Then:
 
 .. code-block:: sh
 
-    sudo apt-get install python3-pip
+    sudo apt-get install docker.io python3-pip
     python3 -m venv .venv
     source .venv/bin/activate
     python3 -m pip install .
@@ -56,7 +56,7 @@ Development (editable install into virtualenv)
 
 .. code-block:: sh
 
-    sudo apt-get install python3-venv
+    sudo apt-get install gramine docker.io python3-venv
     python3 -m venv --system-site-packages .venv
     source .venv/bin/activate
     pip install --editable .

--- a/debian/control
+++ b/debian/control
@@ -23,6 +23,7 @@ Architecture: amd64
 Description: framework for quick development of Gramine apps
  TBD
 Depends:
+ docker.io,
  gramine,
  python3,
  python3-click,


### PR DESCRIPTION
Docker (`docker.io` package) needs to be installed for scag to work. For package installation, this should be handled by `Depends:`, and in manual (pip) installation, `docker.io` needs to be installed explicitly.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/intel/ScaffoldingForGramine/11)
<!-- Reviewable:end -->
