### PR TITLE
Add `and-run` option to the build process.

### DIFF
--- a/Documentation/manpages/scag-build.rst
+++ b/Documentation/manpages/scag-build.rst
@@ -22,6 +22,10 @@ As a result, this command produces a Docker image.
 Options
 =======
 
+.. option:: --and-run
+
+   Automatically run the application after build.
+
 .. option:: --conf <file>
 
     The filename of the scaffolding configuration file. This file is most

--- a/graminescaffolding/__main__.py
+++ b/graminescaffolding/__main__.py
@@ -179,7 +179,9 @@ def setup(ctx, framework, sgx, sgx_key, project_dir, bootstrap, setup_args):
 @click.option('--print-only-image', is_flag=True,
     help='Print only the SHA of the produced docker image, without any'
     ' additional decorators.')
-def build(project_dir, conf, sgx_key, print_only_image):
+@click.option('--and-run', is_flag=True,
+    help='Automatically run the application after build')
+def build(project_dir, conf, sgx_key, print_only_image, and_run):
     """
     Build Gramine application using Scaffolding framework.
     """
@@ -189,6 +191,9 @@ def build(project_dir, conf, sgx_key, print_only_image):
             print(docker_id)
         else:
             print_docker_usage(docker_id, builder)
+
+    if and_run:
+        builder.get_toolchain().run_docker(docker_id)
 
 def build_step(project_dir, filename, sgx_key):
     """


### PR DESCRIPTION
This option allows users to avoid manually copying the docker-id, streamlining the build and run process. It's particularly useful during the development of new apps where frequent builds and runs are common.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/intel/ScaffoldingForGramine/12)
<!-- Reviewable:end -->
