### PR TITLE
Ensure tomli.load uses files opened in binary read mode

### DIFF
--- a/graminescaffolding/__main__.py
+++ b/graminescaffolding/__main__.py
@@ -234,7 +234,7 @@ def build_step(ctx, project_dir, conf):
         ' scag-client.toml config file will be read from the .scag magic'
         ' subdirectory.')
 @click.option('--config', '-f', 'config_file', metavar='FILE',
-    type=click.File('r'),
+    type=click.File('rb'),
     help='Path to scag-client.toml configuration file.')
 @click.option('--request', '-X', 'method', metavar='METHOD', default='GET',
     help='Use another request HTTP method (instead of GET, the default)')


### PR DESCRIPTION
The stack trace:

```
Traceback (most recent call last):
  File "/home/azureuser/osho-scag-tests/ScaffoldingForGramine/.venv/bin/scag-client", line 8, in <module>
    sys.exit(client())
  File "/home/azureuser/osho-scag-tests/ScaffoldingForGramine/.venv/lib/python3.10/site-packages/click/core.py", line 1157, in __call__
    return self.main(*args, **kwargs)
  File "/home/azureuser/osho-scag-tests/ScaffoldingForGramine/.venv/lib/python3.10/site-packages/click/core.py", line 1078, in main
    rv = self.invoke(ctx)
  File "/home/azureuser/osho-scag-tests/ScaffoldingForGramine/.venv/lib/python3.10/site-packages/click/core.py", line 1434, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/home/azureuser/osho-scag-tests/ScaffoldingForGramine/.venv/lib/python3.10/site-packages/click/core.py", line 783, in invoke
    return __callback(*args, **kwargs)
  File "/home/azureuser/osho-scag-tests/ScaffoldingForGramine/.venv/lib/python3.10/site-packages/click/decorators.py", line 33, in new_func
    return f(get_current_context(), *args, **kwargs)
  File "/home/azureuser/osho-scag-tests/ScaffoldingForGramine/.venv/lib/python3.10/site-packages/graminescaffolding/__main__.py", line 277, in client
    config = tomli.load(config_file)
  File "/home/azureuser/osho-scag-tests/ScaffoldingForGramine/.venv/lib/python3.10/site-packages/tomli/_parser.py", line 63, in load
    raise TypeError(
TypeError: File must be opened in binary mode, e.g. use `open('foo.toml', 'rb')`
```

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/intel/ScaffoldingForGramine/37)
<!-- Reviewable:end -->
