### PR TITLE
Add --expose 8000 port by default to docker run command

### DIFF
--- a/graminescaffolding/__main__.py
+++ b/graminescaffolding/__main__.py
@@ -70,6 +70,7 @@ def get_docker_run_command(docker_id, *extra_opts):
         'docker', 'run',
         '--device', '/dev/sgx_enclave',
         '--volume', '/var/run/aesmd/aesm.socket:/var/run/aesmd/aesm.socket',
+        '--publish', '8080:8080',
         *extra_opts,
         docker_id
     ]


### PR DESCRIPTION
Added port 8000 to be exposed by default to match whats done in testing scripts

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/intel/ScaffoldingForGramine/40)
<!-- Reviewable:end -->
